### PR TITLE
Added supervisor conf.d directory configuration

### DIFF
--- a/supervisor/Dockerfile
+++ b/supervisor/Dockerfile
@@ -13,3 +13,5 @@ RUN apt-get -y upgrade
 RUN apt-get -y install python-setuptools
 RUN easy_install supervisor
 RUN mkdir -p /var/log/supervisor
+
+ADD supervisor.conf /etc/supervisor.conf

--- a/supervisor/supervisor.conf
+++ b/supervisor/supervisor.conf
@@ -1,0 +1,6 @@
+[supervisord]
+nodaemon=true
+
+[include]
+files = /etc/supervisor/conf.d/*.conf
+


### PR DESCRIPTION
Supervisor allows configuration file includes. See http://supervisord.org/configuration.html

Therefore, let's add a basic supervisor.conf file under /etc/supervisor.conf which includes all files under /etc/supervisor/conf.d. This way Dockerfiles that extend FROM this base image can ADD a specific supervisor.conf file, such as jenkins-supervisor.conf or elasticsearch-supervisor.conf which will be picked up automatically when the supervisor daemon is run as a CMD.
