### PR TITLE
Changed elasticsearch-1.x to elasticsearch in build_all.sh

### DIFF
--- a/build_all.sh
+++ b/build_all.sh
@@ -6,7 +6,7 @@ cd ../mongo
 ./build.sh
 cd ../jdk7-oracle
 ./build.sh
-cd ../elasticsearch-1.x
+cd ../elasticsearch
 ./build.sh
 cd ../tomcat7
 ./build.sh


### PR DESCRIPTION
When running build_all.sh the elasticsearch image is not built.

Also, Jenkins does not have a build.sh.
